### PR TITLE
Update to 2019.3 + some apt upgrade retries

### DIFF
--- a/packer-scripts/ansible.sh
+++ b/packer-scripts/ansible.sh
@@ -2,7 +2,11 @@
 
 # Install Ansible repository.
 apt-get -y update
-apt-get -y install pip
+apt-get -y install python-pip
 
 # Install Ansible.
+pip install --upgrade ansible ||\
+pip install --upgrade ansible ||\
+pip install --upgrade ansible ||\
+pip install --upgrade ansible ||\
 pip install --upgrade ansible

--- a/packer-scripts/cleanup.sh
+++ b/packer-scripts/cleanup.sh
@@ -1,6 +1,7 @@
 # Apt cleanup.
 apt autoremove
 apt update
+apt-get clean
 
 # Delete unneeded files.
 rm -f /home/vagrant/*.sh

--- a/packer-scripts/vmware-tools.sh
+++ b/packer-scripts/vmware-tools.sh
@@ -1,3 +1,14 @@
+# Add a few retries just in case network connectivity is shaky
+sudo apt-get update ||\
+sudo apt-get update ||\
+sudo apt-get update ||\
+sudo apt-get update ||\
 sudo apt-get update
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" dist-upgrade -yq ||\
+sudo DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" dist-upgrade -yq ||\
+sudo DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" dist-upgrade -yq ||\
+sudo DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" dist-upgrade -yq ||\
 sudo DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" dist-upgrade -yq
+
 sudo apt-get install -y open-vm-tools

--- a/packer-vagrant.json
+++ b/packer-vagrant.json
@@ -71,11 +71,11 @@
       "headless": false,
       "http_directory": "http",
       "iso_urls": [
-        "iso/kali-linux-2018.2-amd64.iso",
-        "http://cdimage.kali.org/kali-2018.2/kali-linux-2018.2-amd64.iso"
+        "iso/kali-linux-2019.3-amd64.iso",
+        "https://cdimage.kali.org/kali-2019.3/kali-linux-2019.3-amd64.iso"
       ],
       "iso_checksum_type": "sha256",
-      "iso_checksum": "56f677e2edfb2efcd0b08662ddde824e254c3d53567ebbbcdbbf5c03efd9bc0f",
+      "iso_checksum": "d9bc23ad1ed2af7f0170dc6d15aec58be2f1a0a5be6751ce067654b753ef7020",
       "ssh_username": "root",
       "ssh_password": "toor",
       "ssh_port": 22,
@@ -133,11 +133,11 @@
       "headless": true,
       "http_directory": "http",
       "iso_urls": [
-        "iso/kali-linux-2018.2-amd64.iso",
-        "http://cdimage.kali.org/kali-2018.2/kali-linux-2018.2-amd64.iso"
+        "iso/kali-linux-2019.3-amd64.iso",
+        "https://cdimage.kali.org/kali-2019.3/kali-linux-2019.3-amd64.iso"
       ],
       "iso_checksum_type": "sha256",
-      "iso_checksum": "56f677e2edfb2efcd0b08662ddde824e254c3d53567ebbbcdbbf5c03efd9bc0f",
+      "iso_checksum": "d9bc23ad1ed2af7f0170dc6d15aec58be2f1a0a5be6751ce067654b753ef7020",
       "output_directory": "output-vmware-iso",
       "ssh_username": "root",
       "ssh_password": "toor",


### PR DESCRIPTION
Here are some proposed changes :
- Changed the base image to 2019.3
- Added some retries for package upgrades which may result in failed builds (vmware only)

These have been tested on MacOS.

